### PR TITLE
Fixing http firewall target

### DIFF
--- a/modules/firewall/main.tf
+++ b/modules/firewall/main.tf
@@ -27,6 +27,6 @@ resource "google_compute_firewall" "allow-http" {
     ports    = ["80"]
   }
 
-  target_tags   = ["http-server2"]
+  target_tags   = ["http-server"]
   source_ranges = ["0.0.0.0/0"]
 }


### PR DESCRIPTION
On line 15, fix the "http-server**2**" typo in the target_tags field.
The value must be "http-server".